### PR TITLE
bugfix: filter number of cores properly in benchmark visualization code

### DIFF
--- a/benchutils/cmd/vizall/main.go
+++ b/benchutils/cmd/vizall/main.go
@@ -5,6 +5,7 @@ import (
 	"image/color"
 	"log"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -46,7 +47,8 @@ func main() {
 	results := make(map[string][]Result)
 	for key, value := range set {
 		benchmark := strings.Split(key, "/")[1] // get the non-generic part of the name
-		benchmark = strings.TrimSuffix(benchmark, "-4")
+		// remove suffix of the number of CPU cores
+		benchmark = regexp.MustCompile("-[0-9]+$").ReplaceAllString(benchmark, "")
 		parts := strings.Split(benchmark, ",")
 		channels, _ := strconv.Atoi(strings.Split(parts[0], ":")[1])
 		elements, _ := strconv.Atoi(strings.Split(parts[1], ":")[1])

--- a/benchutils/cmd/vizsimple/main.go
+++ b/benchutils/cmd/vizsimple/main.go
@@ -6,6 +6,7 @@ import (
 	"image/color"
 	"log"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -66,7 +67,8 @@ func main() {
 	results := make(map[string][]Result)
 	for key, value := range set {
 		benchmark := strings.Split(key, "/")[1] // get the non-generic part of the name
-		benchmark = strings.TrimSuffix(benchmark, "-4")
+		// remove suffix of the number of CPU cores
+		benchmark = regexp.MustCompile("-[0-9]+$").ReplaceAllString(benchmark, "")
 		parts := strings.Split(benchmark, ",")
 		channels, _ := strconv.Atoi(strings.Split(parts[0], ":")[1])
 		if filterByChannels && channels != channelsFilter {


### PR DESCRIPTION
This code was written on a four-core machine, and so I filtered the -4
extensions to each benchmark without realizing what it represented. This
caused it to break when run on machines with a different core count than
mine. The breakage resulted in each benchmark being given the default
color of white, instead of the preset colors.

Signed-off-by: Chris Waldon <chris.waldon@ibm.com>

Fixes #3 (I think)

@zomg Does this fix your problem?